### PR TITLE
chore(security): SHA-pin Actions + per-job permissions (Phase 3)

### DIFF
--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -9,20 +9,31 @@ on:
     paths-ignore:
       - 'ios/**'
       - 'readme.md'
+
+# Workflow-level default: read-only access. Per-job overrides below where writes are needed.
+permissions:
+  contents: read
+
 jobs:
   main:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: checkout sources
-        uses: actions/checkout@v3
+        # actions/checkout@v3 pinned to commit SHA per security hardening Phase 3 (CM baseline mirror).
+        # Dependabot github-actions ecosystem will surface major-version bumps as separate PRs.
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
 
       - name: use Node.js 20.x
-        uses: actions/setup-node@v3
+        # actions/setup-node@v3 pinned to commit SHA.
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610
         with:
           node-version: 20
 
       - name: Set up Java
-        uses: actions/setup-java@v2
+        # actions/setup-java@v2 pinned to commit SHA.
+        uses: actions/setup-java@91d3aa4956ec4a53e477c4907347b5e3481be8c9
         with:
           distribution: 'temurin'
           java-version: 21
@@ -47,7 +58,8 @@ jobs:
           mv -v app-debug.apk "${name}"
 
       - name: upload app
-        uses: actions/upload-artifact@v4
+        # actions/upload-artifact@v4 pinned to commit SHA.
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: audiobookshelf-apk
           path: android/app/build/outputs/apk/debug/*.apk

--- a/.github/workflows/close-issues-on-release.yml
+++ b/.github/workflows/close-issues-on-release.yml
@@ -10,6 +10,9 @@ permissions:
 jobs:
   comment:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
     steps:
       - name: Close issues marked as fixed upon a release.
         uses: gcampbell-msft/fixed-pending-release@7fa1b75a0c04bcd4b375110522878e5f6100cff5

--- a/.github/workflows/close_blank_issues.yaml
+++ b/.github/workflows/close_blank_issues.yaml
@@ -5,20 +5,26 @@ on:
     types:
       - opened
 
+# Workflow-level default + explicit per-job permissions below per defense-in-depth.
 permissions:
+  contents: read
   issues: write
 
 jobs:
   close_issue:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
 
     steps:
       - name: Check issue headings
-        uses: actions/github-script@v6
+        # actions/github-script@v6 pinned to commit SHA per security hardening Phase 3.
+        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410
         with:
           script: |
             const issueBody = context.payload.issue.body || "";
-            
+
             // Match Markdown headings (e.g., # Heading, ## Heading)
             const headingRegex = /^(#{1,6})\s.+/gm;
             const headings = [...issueBody.matchAll(headingRegex)];

--- a/.github/workflows/deploy-apk.yml
+++ b/.github/workflows/deploy-apk.yml
@@ -8,20 +8,29 @@ on:
       - 'ios/**'
       - 'readme.md'
 
+# Workflow-level default: read-only. Per-job overrides below.
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: checkout sources
-        uses: actions/checkout@v3
+        # actions/checkout@v3 pinned to commit SHA per security hardening Phase 3.
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
 
       - name: use Node.js 20.x
-        uses: actions/setup-node@v3
+        # actions/setup-node@v3 pinned to commit SHA.
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610
         with:
           node-version: 20
 
       - name: Set up Java
-        uses: actions/setup-java@v2
+        # actions/setup-java@v2 pinned to commit SHA.
+        uses: actions/setup-java@91d3aa4956ec4a53e477c4907347b5e3481be8c9
         with:
           distribution: 'temurin'
           java-version: 21
@@ -60,7 +69,8 @@ jobs:
           sed -i "s/__APK__/$(ls *apk)/g" index.html
 
       - name: upload test page artifact
-        uses: actions/upload-pages-artifact@v3
+        # actions/upload-pages-artifact@v3 pinned to commit SHA.
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa
         with:
           path: ./ghpages
 
@@ -68,6 +78,7 @@ jobs:
     needs: build
 
     permissions:
+      contents: read
       pages: write
       id-token: write
 
@@ -79,4 +90,5 @@ jobs:
     steps:
       - name: deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        # actions/deploy-pages@v4 pinned to commit SHA.
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e

--- a/.github/workflows/i18n-check.yml
+++ b/.github/workflows/i18n-check.yml
@@ -6,23 +6,33 @@ on:
     paths:
       - strings/** # Should only check if any strings changed
 
+# Workflow-level default: read-only.
+permissions:
+  contents: read
+
 jobs:
   update_translations:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
     # Check out the repository
     - name: Checkout repository
-      uses: actions/checkout@v4
+      # actions/checkout@v4 pinned to commit SHA per security hardening Phase 3.
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
     # Set up node to run the javascript
     - name: Set up node
-      uses: actions/setup-node@v4
+      # actions/setup-node@v4 pinned to commit SHA.
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
       with:
         node-version: '20'
 
     # The only argument is the `directory`, which is where the i18n files are
     # stored.
     - name: Run Update JSON Files action
-      uses: audiobookshelf/audiobookshelf-i18n-updater@v1.3.0
+      # audiobookshelf/audiobookshelf-i18n-updater@v1.3.0 pinned to commit SHA.
+      # First-party action under the upstream org; still pinned per defense-in-depth.
+      uses: audiobookshelf/audiobookshelf-i18n-updater@f827a936bfaae6ceee4babf807bf8b5cc20efab4
       with:
         directory: 'strings/'  # Adjust the directory path as needed


### PR DESCRIPTION
Phase 3 of the security hardening pass. Mirrors the CM / ws-scrcpy-web baseline.

## What this changes

10 SHA pins across 5 workflow files (one third-party action already pinned by upstream skipped):

| Action | Pinned SHA |
|---|---|
| `actions/checkout@v3` | `f43a0e5ff2bd294095638e18286ca9a3d1956744` |
| `actions/checkout@v4` | `34e114876b0b11c390a56381ad16ebd13914f8d5` |
| `actions/setup-node@v3` | `3235b876344d2a9aa001b8d1453c930bba69e610` |
| `actions/setup-node@v4` | `49933ea5288caeca8642d1e84afbd3f7d6820020` |
| `actions/setup-java@v2` | `91d3aa4956ec4a53e477c4907347b5e3481be8c9` |
| `actions/upload-artifact@v4` | `ea165f8d65b6e75b540449e92b4886f43607fa02` |
| `actions/upload-pages-artifact@v3` | `56afc609e74202658d3ffba0e8f6dda462b719fa` |
| `actions/deploy-pages@v4` | `d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e` |
| `actions/github-script@v6` | `d7906e4ad0b1822421a7e6a35d5ca353c962f410` |
| `audiobookshelf/audiobookshelf-i18n-updater@v1.3.0` | `f827a936bfaae6ceee4babf807bf8b5cc20efab4` |

Per-job permissions blocks added to all 5 workflows (workflow-level default + per-job override). Defense in depth.

## Trade-off

Future upstream syncs of `advplyr/audiobookshelf-app` will conflict on these 5 files. Resolution playbook: keep our SHA pins + permissions, merge upstream's logic changes.

## Test plan

- [ ] Verify Build APK workflow runs successfully on this PR
- [ ] Verify i18n-check runs successfully on this PR
- [ ] After merge, confirm CodeQL default setup picks up the hardened workflows on its next scan (expect zero `actions/missing-workflow-permissions` alerts)