### PR TITLE
Revert Phase 3: restore upstream-vanilla workflow files

### DIFF
--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -9,31 +9,20 @@ on:
     paths-ignore:
       - 'ios/**'
       - 'readme.md'
-
-# Workflow-level default: read-only access. Per-job overrides below where writes are needed.
-permissions:
-  contents: read
-
 jobs:
   main:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
     steps:
       - name: checkout sources
-        # actions/checkout@v3 pinned to commit SHA per security hardening Phase 3 (CM baseline mirror).
-        # Dependabot github-actions ecosystem will surface major-version bumps as separate PRs.
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
+        uses: actions/checkout@v3
 
       - name: use Node.js 20.x
-        # actions/setup-node@v3 pinned to commit SHA.
-        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610
+        uses: actions/setup-node@v3
         with:
           node-version: 20
 
       - name: Set up Java
-        # actions/setup-java@v2 pinned to commit SHA.
-        uses: actions/setup-java@91d3aa4956ec4a53e477c4907347b5e3481be8c9
+        uses: actions/setup-java@v2
         with:
           distribution: 'temurin'
           java-version: 21
@@ -58,8 +47,7 @@ jobs:
           mv -v app-debug.apk "${name}"
 
       - name: upload app
-        # actions/upload-artifact@v4 pinned to commit SHA.
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        uses: actions/upload-artifact@v4
         with:
           name: audiobookshelf-apk
           path: android/app/build/outputs/apk/debug/*.apk

--- a/.github/workflows/close-issues-on-release.yml
+++ b/.github/workflows/close-issues-on-release.yml
@@ -10,9 +10,6 @@ permissions:
 jobs:
   comment:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      issues: write
     steps:
       - name: Close issues marked as fixed upon a release.
         uses: gcampbell-msft/fixed-pending-release@7fa1b75a0c04bcd4b375110522878e5f6100cff5

--- a/.github/workflows/close_blank_issues.yaml
+++ b/.github/workflows/close_blank_issues.yaml
@@ -5,26 +5,20 @@ on:
     types:
       - opened
 
-# Workflow-level default + explicit per-job permissions below per defense-in-depth.
 permissions:
-  contents: read
   issues: write
 
 jobs:
   close_issue:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      issues: write
 
     steps:
       - name: Check issue headings
-        # actions/github-script@v6 pinned to commit SHA per security hardening Phase 3.
-        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410
+        uses: actions/github-script@v6
         with:
           script: |
             const issueBody = context.payload.issue.body || "";
-
+            
             // Match Markdown headings (e.g., # Heading, ## Heading)
             const headingRegex = /^(#{1,6})\s.+/gm;
             const headings = [...issueBody.matchAll(headingRegex)];

--- a/.github/workflows/deploy-apk.yml
+++ b/.github/workflows/deploy-apk.yml
@@ -8,29 +8,20 @@ on:
       - 'ios/**'
       - 'readme.md'
 
-# Workflow-level default: read-only. Per-job overrides below.
-permissions:
-  contents: read
-
 jobs:
   build:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
     steps:
       - name: checkout sources
-        # actions/checkout@v3 pinned to commit SHA per security hardening Phase 3.
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
+        uses: actions/checkout@v3
 
       - name: use Node.js 20.x
-        # actions/setup-node@v3 pinned to commit SHA.
-        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610
+        uses: actions/setup-node@v3
         with:
           node-version: 20
 
       - name: Set up Java
-        # actions/setup-java@v2 pinned to commit SHA.
-        uses: actions/setup-java@91d3aa4956ec4a53e477c4907347b5e3481be8c9
+        uses: actions/setup-java@v2
         with:
           distribution: 'temurin'
           java-version: 21
@@ -69,8 +60,7 @@ jobs:
           sed -i "s/__APK__/$(ls *apk)/g" index.html
 
       - name: upload test page artifact
-        # actions/upload-pages-artifact@v3 pinned to commit SHA.
-        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa
+        uses: actions/upload-pages-artifact@v3
         with:
           path: ./ghpages
 
@@ -78,7 +68,6 @@ jobs:
     needs: build
 
     permissions:
-      contents: read
       pages: write
       id-token: write
 
@@ -90,5 +79,4 @@ jobs:
     steps:
       - name: deploy to GitHub Pages
         id: deployment
-        # actions/deploy-pages@v4 pinned to commit SHA.
-        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/i18n-check.yml
+++ b/.github/workflows/i18n-check.yml
@@ -6,33 +6,23 @@ on:
     paths:
       - strings/** # Should only check if any strings changed
 
-# Workflow-level default: read-only.
-permissions:
-  contents: read
-
 jobs:
   update_translations:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
     steps:
     # Check out the repository
     - name: Checkout repository
-      # actions/checkout@v4 pinned to commit SHA per security hardening Phase 3.
-      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      uses: actions/checkout@v4
 
     # Set up node to run the javascript
     - name: Set up node
-      # actions/setup-node@v4 pinned to commit SHA.
-      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+      uses: actions/setup-node@v4
       with:
         node-version: '20'
 
     # The only argument is the `directory`, which is where the i18n files are
     # stored.
     - name: Run Update JSON Files action
-      # audiobookshelf/audiobookshelf-i18n-updater@v1.3.0 pinned to commit SHA.
-      # First-party action under the upstream org; still pinned per defense-in-depth.
-      uses: audiobookshelf/audiobookshelf-i18n-updater@f827a936bfaae6ceee4babf807bf8b5cc20efab4
+      uses: audiobookshelf/audiobookshelf-i18n-updater@v1.3.0
       with:
         directory: 'strings/'  # Adjust the directory path as needed


### PR DESCRIPTION
Reverts #13 (commit `730a959e`).

## Why

Phase 3 hardened upstream's workflow files in our fork. Reflection on the engineering-quality-signal motivation: the maintainer won't see these changes (we won't PR workflow modifications upstream as part of the 9-PR TV series), so the divergence cost (manual merge on every upstream sync touching the 5 workflow files) buys us nothing visible to upstream and only protects OUR CI.

For the maintainer relationship, "don't touch upstream's code unless required" wins.

## What this restores

- `actions/checkout@v3`, `setup-node@v3`, `setup-java@v2`, `github-script@v6`, `upload-artifact@v4`, `upload-pages-artifact@v3`, `deploy-pages@v4`, `audiobookshelf-i18n-updater@v1.3.0` → back to upstream's floating-tag form
- Per-job permissions blocks → removed (workflow-level on `close-issues-on-release.yml` + `close_blank_issues.yaml` already existed upstream; those stay)

## What stays from the security pass

- Phase 1: Dependabot vulnerability alerts + security updates + CodeQL default setup + `.github/dependabot.yml` (intact — new files, no upstream conflict)
- Phase 2: rulesets on `android-tv-dpad-navigation` + `android-tv-v*` tags (intact — API-side, no file conflict)
- Phase 4: `.github/workflows/attest-release-apk.yml` (intact — new file, no upstream conflict)

## What this leaves on the table (deferred)

A follow-up TODO will land in `todo_abs_tv.md` for "offer Phase 3 hardening as a goodwill PR to advplyr/audiobookshelf-app once the 9-PR TV series builds a relationship with the maintainer." Won't be actioned until we have an established channel.

## Live consequences

- 3 CodeQL `actions/missing-workflow-permissions` alerts on master remain — these are upstream's responsibility
- Floating-tag actions remain a tag-mutability risk in CI — but it's UPSTREAM's risk we're not making worse