### PR TITLE
ci: Dependabot auto-merge workflow + config on dev branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,74 @@
+# Dependabot configuration for the bilbospocketses/abs-app fork.
+#
+# Branch topology (set 2026-06-03):
+#   - master is a PURE upstream-sync mirror of advplyr/audiobookshelf-app. We
+#     never develop on it and Dependabot never targets it.
+#   - android-tv-dpad-navigation is our long-lived dev branch AND the repo's
+#     default branch. All of our work -- features and dependency bumps -- lands
+#     here until it is PR'd upstream.
+#
+# Why the dev branch is the default: Dependabot SECURITY updates can only target
+# the default branch (the target-branch setting below governs only VERSION
+# updates). Making the dev branch the default routes security PRs onto the dev
+# line too, so fixes reach shipped code and master stays a clean mirror.
+#
+# Every ecosystem targets android-tv-dpad-navigation explicitly so version
+# updates are unambiguous; security updates follow the default branch to the
+# same place. Cadence: weekly Monday 08:00 ET, capped at 5 open PRs/ecosystem.
+#
+# Auto-merge: .github/workflows/dependabot-auto-merge.yml enables --auto --squash
+# for patch/minor version bumps and ALL security updates on green CI; non-security
+# major version bumps are labeled needs-manual-review and left for a human.
+
+version: 2
+updates:
+  # --- Web layer (Nuxt 2 / Vue 2 / Capacitor) ---
+  - package-ecosystem: "npm"
+    directory: "/"
+    target-branch: "android-tv-dpad-navigation"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "08:00"
+      timezone: "America/New_York"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "ecosystem/npm"
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+
+  # --- Android native layer ---
+  - package-ecosystem: "gradle"
+    directory: "/android"
+    target-branch: "android-tv-dpad-navigation"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "08:00"
+      timezone: "America/New_York"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "ecosystem/gradle"
+    commit-message:
+      prefix: "deps(android)"
+      include: "scope"
+
+  # --- GitHub Actions workflows (SHA pin updates) ---
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    target-branch: "android-tv-dpad-navigation"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "08:00"
+      timezone: "America/New_York"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "ecosystem/github-actions"
+    commit-message:
+      prefix: "chore(ci)"
+      include: "scope"

--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -40,11 +40,15 @@ jobs:
         run: ./android/gradlew assembleDebug -p android --no-daemon
 
       - name: rename apk
-        working-directory: android/app/build/outputs/apk/debug/
         run: |
+          set -e
+          src="$(find android/app/build/outputs/apk -name '*.apk' -print -quit)"
+          if [ -z "$src" ]; then
+            echo "No APK produced under android/app/build/outputs/apk"; exit 1
+          fi
           build="$(date +%Y%m%d-%H%M%S)-$(git rev-parse --short HEAD)"
-          name="audiobookshelf-${build}.apk"
-          mv -v app-debug.apk "${name}"
+          mkdir -p android/app/build/outputs/apk/debug
+          mv -v "$src" "android/app/build/outputs/apk/debug/audiobookshelf-${build}.apk"
 
       - name: upload app
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -1,14 +1,12 @@
 name: Build APK
 
 on:
+  workflow_dispatch:
+  # Filterless push so `main` runs on EVERY commit/PR (incl. .github-only changes
+  # like github-actions Dependabot bumps) -- it's a required status check, and a
+  # required check that doesn't run on some PRs would block them. Single push-event
+  # run per commit keeps the `main` context unambiguous for the ruleset gate.
   push:
-    paths-ignore:
-      - 'ios/**'
-      - 'readme.md'
-  pull_request:
-    paths-ignore:
-      - 'ios/**'
-      - 'readme.md'
 jobs:
   main:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -1,12 +1,14 @@
 name: Build APK
 
 on:
-  workflow_dispatch:
-  # Filterless push so `main` runs on EVERY commit/PR (incl. .github-only changes
-  # like github-actions Dependabot bumps) -- it's a required status check, and a
-  # required check that doesn't run on some PRs would block them. Single push-event
-  # run per commit keeps the `main` context unambiguous for the ruleset gate.
   push:
+    paths-ignore:
+      - 'ios/**'
+      - 'readme.md'
+  pull_request:
+    paths-ignore:
+      - 'ios/**'
+      - 'readme.md'
 jobs:
   main:
     runs-on: ubuntu-latest

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,44 @@
+name: Dependabot auto-merge
+
+# Auto-merges Dependabot PRs once CI is green:
+#   - patch / minor version bumps        -> auto-merge (squash)
+#   - security updates (any bump size)   -> auto-merge (squash)
+#   - non-security MAJOR version bumps    -> labeled needs-manual-review, left for a human
+#
+# Relies on two repo settings (both enabled 2026-06-03):
+#   - "Allow auto-merge"                 -> lets --auto queue the merge
+#   - "Automatically delete head branches" -> deletes the dependabot/* branch post-merge
+# The merge genuinely WAITS for CI because the dev-branch ruleset requires the
+# `main` status check (build-apk.yml). pull_request_target runs the workflow from
+# the base branch, so this file must live on the branch Dependabot targets.
+
+on: pull_request_target
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
+
+      - name: Enable auto-merge (patch/minor, or any security update)
+        if: ${{ steps.meta.outputs.update-type != 'version-update:semver-major' || steps.meta.outputs.ghsa-id != '' }}
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Hold non-security major bump for manual review
+        if: ${{ steps.meta.outputs.update-type == 'version-update:semver-major' && steps.meta.outputs.ghsa-id == '' }}
+        run: |
+          gh pr edit "$PR_URL" --add-label "needs-manual-review"
+          gh pr comment "$PR_URL" --body "🚧 Non-security **major** version bump — auto-merge intentionally skipped. Review and merge manually."
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Sets up hands-off Dependabot handling so security/version PRs self-clear instead of accumulating as orphaned branches.

## What
- **`.github/dependabot.yml`** — relocated to the dev branch (was master-only) and rewritten so all three ecosystems (npm, gradle, github-actions) target `android-tv-dpad-navigation` explicitly. Documents the master-as-pure-mirror topology.
- **`.github/workflows/dependabot-auto-merge.yml`** — `pull_request_target` workflow that enables `--auto --squash` for patch/minor bumps + **all security updates** on green CI, and holds non-security **major** bumps with a `needs-manual-review` label. Action SHA-pinned (`dependabot/fetch-metadata` v3.1.0).

## Why on the dev branch
`master` is the upstream-sync mirror — nothing of ours lands there. Dependabot *security* updates can only target the **default** branch, so the repo default is being switched to `android-tv-dpad-navigation` (this PR + the swap together). Then security fixes reach shipped code and `master` stays clean.

Paired with repo settings just enabled: **Allow auto-merge** + **Automatically delete head branches**, and a required `main` status check on the dev-branch ruleset so `--auto` actually waits for the build.