### PR TITLE
docs: re-validate decomposition plan to 10-PR series

### DIFF
--- a/docs/PR_DECOMPOSITION_PLAN.md
+++ b/docs/PR_DECOMPOSITION_PLAN.md
@@ -1,10 +1,10 @@
-# Android TV Support — 9-PR Decomposition Plan
+# Android TV Support — 10-PR Decomposition Plan
 
 **Maintainer reference for the upstream PR series replacing #1843**
 
 This document is the canonical reference for how the Android TV support work
 (originally submitted to `advplyr/audiobookshelf-app` as PR #1843, ~7,000 LOC)
-is being split into a series of 9 smaller, focused PRs.
+is being split into a series of 10 smaller, focused PRs.
 
 It is hosted on the **fork** (`bilbospocketses/abs-app`) so that upstream PR
 descriptions can link to a single durable plan without bloating the upstream
@@ -27,14 +27,14 @@ This plan addresses both:
 - **Strip non-code from upstream contributions.** Docs, plans, specs, PDF, and
   screenshots stay on the fork. Each upstream PR contributes a single
   ~25-line `docs/pr-NN-<short-name>.md` linking back to fork-hosted context.
-- **Split the upstream code into a 9-PR series across 3 waves.** Average PR
-  size: ~290 LOC. Largest PR: ~1,560 LOC across 15 focused files.
-- **Refactor the fork to a modular engine structure first** (v1.0.10) so the
-  fork and upstream PRs share one code structure.
+- **Split the upstream code into a 10-PR series across 3 waves.** Average PR
+  size: ~335 LOC. Largest PR: ~1,630 LOC across 17 focused files.
+- **Refactor the fork to a modular engine structure first** (shipped in v1.0.10)
+  so the fork and upstream PRs share one code structure.
 
 Net result: the maintainer-facing review unit changes from `~7,000 LOC × 1 PR`
-to `~2,530 LOC × 9 PRs`, with the largest single PR being `~1,560 LOC across
-15 small files`.
+to ~10 small PRs averaging ~335 LOC, with the largest single PR being
+`~1,630 LOC across 17 small files`.
 
 The architectural choice (TV code in dedicated files like `plugins/tv/` with
 inline gating in shared components) is preserved deliberately. Analysis of an
@@ -45,21 +45,29 @@ spec.
 
 ---
 
-## The 9 PRs at a glance
+## The 10 PRs at a glance
 
 | # | Title | LOC | Wave | Depends on | Files |
 |---|---|---|---|---|---|
 | 1 | Foundation + TV detection | ~125 + 1 binary | 1 | nothing | 11 files (manifest, Kotlin, Vuex, layouts) + tv_banner.png |
 | 2 | Keyboard hygiene (tabindex + keydown.enter.prevent) | ~300 | 1 | nothing | 25+ shared Vue components, additive only |
-| 3 | CSS foundation (tv-focus.css + variable) | ~130 | 1 | nothing | 3 files |
-| 4 | Engine kit — utility modules + page handlers | ~1,560 | 2 | PR 1 | 15 files in `plugins/tv/` (each ≤250 LOC) |
-| 5 | Engine integration — listeners + dispatcher | ~550 | 2 | PR 4 (stacked) | 2 files in `plugins/tv/` + `nuxt.config.js` |
-| 6 | Audio player TV behavior | ~100 | 3 | PR 1, PR 5 | `AudioPlayer.vue` (KeepAwake, close-vs-minimize, History gate, auto-fullscreen) |
-| 7 | Settings + focus-color picker | ~180 | 3 | PR 3, PR 5 | `settings.vue` TV section + `TvFocusColorPicker.vue` |
-| 8 | Server connect form D-pad nav | ~150 | 3 | PR 2, PR 5 | `ServerConnectForm.vue` |
-| 9 | Author detail page | ~120 | 3 | PR 2 | `pages/author/_id.vue` + 3 related Vue files |
+| 3 | Side drawer: hide "Go to Web Client" on TV | ~19 | 1 | nothing (gate inert until PR1) | `SideDrawer.vue` — **shares this file with PR2** |
+| 4 | CSS foundation (tv-focus.css + variable) | ~132 | 1 | nothing | 3 files |
+| 5 | Engine kit — utility modules + page handlers | ~1,630 | 2 | PR 1 | 17 files in `plugins/tv/` (each ≤235 LOC) |
+| 6 | Engine integration — listeners + dispatcher | ~615 | 2 | PR 5 (stacked) | 2 files in `plugins/tv/` + `nuxt.config.js` |
+| 7 | Audio player TV behavior | ~100 | 3 | PR 1, PR 6 | `AudioPlayer.vue` (KeepAwake, close-vs-minimize, History gate, auto-fullscreen) |
+| 8 | Settings + focus-color picker | ~180 | 3 | PR 4, PR 6 | `settings.vue` TV section + `TvFocusColorPicker.vue` |
+| 9 | Server connect form D-pad nav | ~150 | 3 | PR 2, PR 6 | `ServerConnectForm.vue` |
+| 10 | Author detail page | ~120 | 3 | PR 2 | `pages/author/_id.vue` + 3 related Vue files |
 
-**Average PR size: ~290 LOC. Largest single file in any PR: ~250 LOC.**
+**Average PR size: ~335 LOC. Largest single PR: ~1,630 LOC across 17 files
+(each file ≤235 LOC).**
+
+The total upstreamable code (~3,100 LOC) is higher than the original estimate
+of ~2,530 because the engine is now counted in its modular form (PR5 + PR6 ≈
+2,245 LOC vs. the old 1,675-LOC monolith — the ~28% modularization overhead the
+design spec predicted) plus the v1.0.11 fast-scroll fixes that landed in the
+engine. Per-PR review size is what matters, and it stays small.
 
 ---
 
@@ -67,48 +75,59 @@ spec.
 
 ### Wave 1 — foundation (parallel)
 
-PRs 1, 2, and 3 are fully independent. Submit simultaneously off `upstream/master`.
-Each PR is small, additive, and has no dependencies. Phone/tablet behavior is
+PRs 1, 2, 3, and 4 are independent and submit simultaneously off
+`upstream/master`. Each is small and additive; phone/tablet behavior is
 byte-identical to upstream after Wave 1 lands — the foundation enables TV but
-activates nothing visible until Wave 2.
+activates no navigation until Wave 2.
+
+**One file-overlap note:** PR2 (keyboard hygiene) and PR3 (hide "Go to Web
+Client" on TV) both touch `components/app/SideDrawer.vue`. They edit different
+regions, but whichever merges second may need a trivial rebase. Everything else
+in Wave 1 is fully disjoint.
+
+PR3 hides the "Go to Web Client" side-drawer item on Android TV (a TV has no
+browser to hand off to). It is gated on `isAndroidTv`, so it is inert until
+PR1's detection state merges — and harmless before then (the item simply
+remains visible, i.e. upstream's current behavior).
 
 ### Wave 2 — engine (sequential)
 
-PR 4 (engine kit) opens after Wave 1's PR 1 merges. It ships dormant library
+PR 5 (engine kit) opens after Wave 1's PR 1 merges. It ships dormant library
 code — modules that export functions but attach to nothing at runtime.
 
-PR 5 (engine integration) stacks on PR 4's branch. It activates the engine by
+PR 6 (engine integration) stacks on PR 5's branch. It activates the engine by
 registering the global keydown listener and wiring router/store/eventBus hooks.
 
-The PR 4/5 split lets the maintainer review the function library separately
+The PR 5/6 split lets the maintainer review the function library separately
 from the wiring that turns it on.
 
 ### Wave 3 — features (parallel)
 
-PRs 6, 7, 8, and 9 open after Wave 2's PR 5 merges. Each is small, independent,
+PRs 7, 8, 9, and 10 open after Wave 2's PR 6 merges. Each is small, independent,
 and adds a TV-specific feature on top of the live engine. Submit in parallel.
 
-PR 9 (author detail page) is arguably non-TV-specific — the page itself adds
+PR 10 (author detail page) is arguably non-TV-specific — the page itself adds
 general functionality that mobile users could also benefit from. The PR
 description flags this for the maintainer's discretion.
 
 ---
 
-## The v1.0.10 fork refactor (precedes upstream submission)
+## The v1.0.10 fork refactor (preceded upstream submission)
 
-Before any upstream PR opens, the fork ships v1.0.10 — a single
-behavior-preserving commit that splits the current 1,675-line
-`plugins/tv-navigation.js` monolith into 18 focused modules under
-`plugins/tv/`, sharing state through a `tvContext` singleton object.
+Before any upstream PR opens, the fork shipped v1.0.10 — a single
+behavior-preserving commit that split the former 1,675-line
+`plugins/tv-navigation.js` monolith into focused modules under `plugins/tv/`,
+sharing state through a `tvContext` singleton object. As of v1.0.11 the modular
+tree is **19 files** (the refactor plus the fast-scroll column-drift fix, which
+added `selectors.js` and extended `spatialNav.js`/`gridNav.js`/`listeners.js`).
 
 **Why first:** so the fork and upstream PRs share one code structure. Without
 this, every upstream PR would require translating between the monolithic fork
 structure and the modular upstream submission — ongoing dual-maintenance pain.
 
-**Behavior parity is the success criterion** — the refactor moves code without
-changing it. ESLint clean, full 42-item TV manual checklist pass on Google TV
-Streamer 4K, plus phone smoke before merge. Any divergence is a bug to fix
-before release.
+**Behavior parity was the success criterion** — the refactor moved code without
+changing it. ESLint clean, full TV manual checklist pass on Google TV Streamer
+4K, plus phone smoke before merge.
 
 **Release notes:** *"Internal refactor: split `tv-navigation.js` into focused
 modules under `plugins/tv/`. No user-visible changes. Foundation for future
@@ -118,12 +137,25 @@ upstream PR submission."*
 
 ## What happens to PR #1843
 
-Closed with a comment redirecting to this plan:
+Closed with a comment redirecting to this plan. Draft below — it acknowledges
+the gap since the 2026-05-25 "incoming shortly" comment, and corrects that
+note's "each PR gated on the next" framing (Wave 1 is actually independent):
 
-> Closing in favor of a 9-PR series that addresses the volume feedback. See
-> [bilbospocketses/abs-app — PR_DECOMPOSITION_PLAN.md](this document) for
-> the full plan and rationale. First PR (foundation + TV detection) opening
-> at [link] shortly.
+> Apologies for the gap since my last note here. I used the time to land a few
+> stability fixes on the fork first — most notably a long-standing fast-scroll
+> focus bug — so the upstream series starts from a solid base rather than
+> chasing known issues across PRs.
+>
+> Closing this in favor of the 10-PR series we discussed, which addresses the
+> volume feedback. Two changes from this PR: the internal docs/specs/PDF are
+> stripped out (each PR links back to a plan on my fork instead of carrying
+> them), and the code is split into small, focused PRs. The first wave —
+> foundation + TV detection, keyboard hygiene, a one-item side-drawer gate, and
+> the CSS foundation — is **fully independent: each can be reviewed and merged
+> on its own, in any order** (my earlier "gated on the next" note was wrong for
+> this wave). Later waves build on the foundation. Full breakdown, dependency
+> graph, and rationale: [PR_DECOMPOSITION_PLAN.md](link). First PRs opening
+> shortly.
 
 ---
 
@@ -138,8 +170,8 @@ Each upstream PR adds a single file at `docs/pr-NN-<short-name>.md` (e.g.,
 - 1 sentence on the testing performed
 - Dependency relationships within the series
 
-No PR edits any other PR's docs file. After all 9 PRs merge, upstream `docs/`
-contains 9 lightweight context files. The introduction of `docs/` is
+No PR edits any other PR's docs file. After all 10 PRs merge, upstream `docs/`
+contains 10 lightweight context files. The introduction of `docs/` is
 deliberate but minimal — maintainer is free to repurpose the directory
 later for their own conventions.
 
@@ -149,13 +181,13 @@ later for their own conventions.
 
 | Phase | Activity | Estimated effort |
 |---|---|---|
-| 1 | Publish v1.0.10 fork refactor | ~1 day (mechanical + testing + release) |
+| 1 | Publish v1.0.10 fork refactor | ✅ done (shipped) |
 | 2 | Close PR #1843 with redirect | ~15 min |
-| 3 | Submit Wave 1 PRs (1, 2, 3) in parallel | ~2 hours |
+| 3 | Submit Wave 1 PRs (1, 2, 3, 4) in parallel | ~2.5 hours |
 | 4 | Maintainer review/merge of Wave 1 | (variable, days-weeks per PR) |
-| 5 | Submit Wave 2 PRs (4 + stacked 5) | ~3 hours |
+| 5 | Submit Wave 2 PRs (5 + stacked 6) | ~3 hours |
 | 6 | Maintainer review/merge of Wave 2 | (variable) |
-| 7 | Submit Wave 3 PRs (6, 7, 8, 9) in parallel | ~3 hours |
+| 7 | Submit Wave 3 PRs (7, 8, 9, 10) in parallel | ~3 hours |
 | 8 | Maintainer review/merge of Wave 3 | (variable) |
 | 9 | Post-merge cleanup | ~1 day |
 
@@ -186,4 +218,9 @@ spec's Section 10 outlines contingencies for the most likely variations.
 
 ---
 
-**Last updated:** 2026-06-03 (corrected the module count 17→18 and the fork-TODO filename). The per-PR LOC table still reflects the pre-v1.0.11 split; PRs 3/4/5 shift once v1.0.11's I2/I4/I5 land upstream, so the table is pending re-validation after v1.0.11 ships — see fork TODO item 15. Plan originally created 2026-05-18.
+**Last updated:** 2026-06-06 — re-validated after v1.0.11 shipped. Now a
+**10-PR series**: a new PR3 (hide "Go to Web Client" on TV) was inserted in
+Wave 1, shifting the former PRs 3-9 to 4-10. Per-PR LOC refreshed against the
+post-v1.0.11 tree — the engine kit (PR5) is now ~1,630 LOC / 17 files and
+integration (PR6) ~615 LOC, reflecting the column-drift fix. Plan originally
+created 2026-05-18.

--- a/docs/superpowers/specs/2026-05-18-pr-decomposition-and-fork-modularization-design.md
+++ b/docs/superpowers/specs/2026-05-18-pr-decomposition-and-fork-modularization-design.md
@@ -2,8 +2,34 @@
 
 **Date:** 2026-05-18
 **Author:** Jamie Chapman (jchapz30@gmail.com) with Claude
-**Status:** Design approved; awaiting execution authorization
+**Status:** Design approved; execution in progress (Wave 1 not yet opened)
 **Supersedes:** ad-hoc plan to keep `tv-navigation.js` monolithic on upstream PR #1843
+
+---
+
+## ⟳ Re-validation note (2026-06-06, after v1.0.11 shipped)
+
+This spec was written 2026-05-18 as a **9-PR** plan. It is now a **10-PR**
+series. The canonical, current numbering and per-PR sizing live in
+[`docs/PR_DECOMPOSITION_PLAN.md`](../../PR_DECOMPOSITION_PLAN.md); the section
+numbering in **this** spec still uses the original 9-PR scheme except where
+noted. Translation:
+
+- **New PR3** inserted in Wave 1: *hide "Go to Web Client" in the side drawer on
+  Android TV* (~19 LOC, `components/app/SideDrawer.vue`; gated on `isAndroidTv`,
+  shares the file with PR2). The former PRs 3-9 shift to **4-10**.
+- **Engine kit** = this spec's "PR4" = **now PR5** (~1,630 LOC / 17 files).
+- **Engine integration** = this spec's "PR5" = **now PR6** (~615 LOC).
+- **Module roster refreshed** (§3.2): the live `plugins/tv/` tree is **19 files**
+  (was 17 planned). Added since this spec: `selectors.js` (I5 `data-*` target
+  finders), `pageHandlers/navBarEscape.js`, `pageHandlers/playerNav.js`. The
+  planned `pageHandlers/streamContainer.js` is not in the live tree
+  (fullscreen-player keydown now lives in `playerNav.js`). The v1.0.11
+  column-drift fix grew `spatialNav.js`, `gridNav.js`, `listeners.js`, and
+  `context.js`.
+- Architecture decision (§9, external files) is **unchanged and confirmed in
+  the clear** — the maintainer never requested inlining; the fork publicly
+  posted the decompose-plus-docs-split approach on PR #1843 (2026-05-25).
 
 ---
 
@@ -85,29 +111,31 @@ Every other module imports `tvContext` and reads/writes via `tvContext.lastFocus
 - *ESM live bindings of `let` exports:* read-only across modules; doesn't fit mutable state needs.
 - *Pass context as first arg to every helper:* extremely verbose; every call site changes.
 
-### 3.2 File layout in `plugins/tv/` (17 files, ~2,100 LOC total)
+### 3.2 File layout in `plugins/tv/` (19 files, ~2,250 LOC total — refreshed 2026-06-06)
 
 | File | LOC | Contents | PR |
 |---|---|---|---|
-| `context.js` | ~30 | Singleton `tvContext` object | 4 |
-| `visibility.js` | ~150 | `isVisible`, `getAllFocusable`, `centerOf`, `isSameRow` — pure DOM/geometry helpers | 4 |
-| `scrollHelpers.js` | ~100 | `findPageScrollContainer`, `findScrollableParent`, `scrollParentToReveal`, `getScrollBehavior`, `isDetailScrollContainer` | 4 |
-| `focusMemory.js` | ~250 | `getElementFingerprint`, `buildStructuralPath`, `findByStructuralPath`, `restoreFromFingerprint` — fingerprint system | 4 |
-| `spatialNav.js` | ~200 | `findHorizontalTarget`, `findVerticalTarget` — beam-model navigators | 4 |
-| `overlayFocus.js` | ~200 | `getActiveOverlay`, `saveFocusBeforeOverlay`, `restoreFocusAfterOverlay`, `handleOverlayNavigation` | 4 |
-| `focusColor.js` | ~30 | `applyTvFocusColor`, `VALID_TV_FOCUS_HEXES`, `DEFAULT_TV_FOCUS_HEX` | 4 |
-| `focusEntry.js` | ~200 | `focusFirstContentElement`, `isGridPage`, `focusAfterPlayerClose`, `refocusAfterContentChange` | 4 |
-| `pageHandlers/episodeRow.js` | ~110 | `handleEpisodeRow` — podcast/audiobook track row keydown | 4 |
-| `pageHandlers/logsContainer.js` | ~55 | `handleLogsContainer` — logs scroll-page keydown | 4 |
-| `pageHandlers/statsPage.js` | ~85 | `handleStatsPage` — stats page keydown + chart focus | 4 |
-| `pageHandlers/itemPage.js` | ~25 | `handleItemPage` — book/podcast detail keydown | 4 |
-| `pageHandlers/authorPage.js` | ~55 | `handleAuthorPage` — author detail keydown | 4 |
-| `pageHandlers/streamContainer.js` | ~15 | `handleStreamContainer` — stream/transcode page keydown | 4 |
-| `pageHandlers/gridNav.js` | ~95 | `handleGridArrowUp` + `handleGridArrowLeftRight` — grid-page horizontal/vertical | 4 |
-| `listeners.js` | ~400 | `registerRouterHooks`, `registerPlayerWatchers`, `registerModalWatcher`, `registerDrawerWatcher`, `registerEventBusSubscribers` | 5 |
-| `index.js` | ~150 | Nuxt plugin default export, `checkAndInit`, global keydown listener, dispatcher to pageHandlers | 5 |
+| `context.js` | 83 | Singleton `tvContext` object (incl. intended-column state from the column-drift fix) | 4 |
+| `selectors.js` | 21 | `findPlayButton`, `findVisibleSideDrawer` — stable `data-*` target finders (I5; replaced fragile Tailwind-class selectors) | 4 |
+| `visibility.js` | 47 | `isVisible`, `getAllFocusable`, `centerOf`, `isSameRow` — pure DOM/geometry helpers | 4 |
+| `scrollHelpers.js` | 124 | `findPageScrollContainer`, `findScrollableParent`, `scrollParentToReveal`, `getScrollBehavior`, `isDetailScrollContainer` | 4 |
+| `focusMemory.js` | 223 | `getElementFingerprint`, `buildStructuralPath`, `findByStructuralPath`, `restoreFromFingerprint` — fingerprint system | 4 |
+| `spatialNav.js` | 235 | `findHorizontalTarget`, `findVerticalTarget` — beam-model navigators (grew with the column-drift intended-column tracking) | 4 |
+| `overlayFocus.js` | 92 | `getActiveOverlay`, `saveFocusBeforeOverlay`, `restoreFocusAfterOverlay`, `handleOverlayNavigation` | 4 |
+| `focusColor.js` | 25 | `applyTvFocusColor`, `VALID_TV_FOCUS_HEXES`, `DEFAULT_TV_FOCUS_HEX` | 4 |
+| `focusEntry.js` | 131 | `focusFirstContentElement`, `isGridPage`, `focusAfterPlayerClose`, `refocusAfterContentChange` | 4 |
+| `pageHandlers/episodeRow.js` | 124 | `handleEpisodeRow` — podcast/audiobook track row keydown | 4 |
+| `pageHandlers/logsContainer.js` | 64 | `handleLogsContainer` — logs scroll-page keydown | 4 |
+| `pageHandlers/statsPage.js` | 94 | `handleStatsPage` — stats page keydown + chart focus | 4 |
+| `pageHandlers/itemPage.js` | 40 | `handleItemPage` — book/podcast detail keydown | 4 |
+| `pageHandlers/authorPage.js` | 68 | `handleAuthorPage` — author detail keydown | 4 |
+| `pageHandlers/gridNav.js` | 122 | `handleGridArrowUp` + `handleGridArrowLeftRight` — grid-page nav (grew with the column-drift fix) | 4 |
+| `pageHandlers/navBarEscape.js` | 38 | `handleNavBarEscape` — Up-from-content escapes to the appbar back button | 4 |
+| `pageHandlers/playerNav.js` | 102 | `handlePlayerNav` — fullscreen audio-player D-pad nav + Back-to-close (the spec's planned `streamContainer.js` no longer exists) | 4 |
+| `listeners.js` | 468 | `registerRouterHooks`, `registerPlayerWatchers`, `registerModalWatcher`, `registerDrawerWatcher`, `registerEventBusSubscribers` (+ column-drift focusin watcher) | 5 |
+| `index.js` | 147 | Nuxt plugin default export, `checkAndInit`, global keydown listener, dispatcher to pageHandlers | 5 |
 
-**Total: ~2,150 LOC** (current: 1,675 + ~475 of import statements, exports, JSDoc, and module-level scaffolding). Trade-off accepted — per-file reviewability >> the ~28% LOC growth from modularization overhead.
+**Total: 2,248 LOC** across 19 files (live count, 2026-06-06; the former monolith was 1,675 — the ~34% growth is modularization scaffolding plus the v1.0.11 column-drift fix). The **PR column uses this spec's original 9-PR labels** (engine kit = PR4 = **now PR5**; integration = PR5 = **now PR6** — see the re-validation note above). Trade-off accepted — per-file reviewability >> the LOC growth.
 
 ### 3.3 Dependency graph
 
@@ -540,7 +568,12 @@ None at design approval. Items that emerge during execution will be tracked in `
 
 ## Appendix A: file-by-file mapping (`tv-navigation.js` → `plugins/tv/*`)
 
-Approximate line ranges in current `plugins/tv-navigation.js` → target file:
+**Historical (pre-v1.0.10).** This maps the original 1,675-line monolith —
+which no longer exists — onto the modules it was split into. The live roster is
+§3.2 (refreshed 2026-06-06); note that `streamContainer` below was not carried
+over as its own file (fullscreen-player keydown now lives in `playerNav.js`),
+and `selectors.js`/`navBarEscape.js` were added later. Approximate line ranges
+in the former `plugins/tv-navigation.js` → target file:
 
 | Source line range | Function(s) | Target file |
 |---|---|---|


### PR DESCRIPTION
Re-validates the upstream PR decomposition docs after v1.0.11 shipped. Inserts the new PR3 (hide 'Go to Web Client' on Android TV), shifting former PRs 3-9 to 4-10; refreshes the module roster (19 files) and per-PR LOC. Docs only — no code changes.